### PR TITLE
Update footer links

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,11 +35,13 @@ export default function RootLayout({
 
         <footer className="section border-t border-white/10">
           <div className="container flex flex-col items-center gap-3 text-sm text-neutral-400">
-            <div className="flex gap-4">
-              <a href="#" aria-label="X (dummy)" className="hover:text-neutral-200">X</a>
-              <a href="#" aria-label="GitHub (dummy)" className="hover:text-neutral-200">GitHub</a>
-              <a href="#" aria-label="Email (dummy)" className="hover:text-neutral-200">Email</a>
-            </div>
+            <a
+              href="https://github.com/yukihirarinta"
+              aria-label="GitHub"
+              className="hover:text-neutral-200"
+            >
+              GitHub
+            </a>
             <p>© {new Date().getFullYear()} Yukihira Rinta</p>
           </div>
         </footer>


### PR DESCRIPTION
## Summary
- remove unused X and Email footer links
- center the GitHub footer link and point it to the real profile URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3cc56898832eb0164602a3b5846b