### PR TITLE
Adjust blog thumbnail layout

### DIFF
--- a/public/blog-thumbnail.svg
+++ b/public/blog-thumbnail.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">BeaSkyblue Blog Thumbnail</title>
+  <desc id="desc">A centered yellow circle stacked above the text BeaSkyblue on a sky-blue background.</desc>
+  <rect width="1200" height="630" fill="#7EC1E7"/>
+  <foreignObject width="1200" height="630">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="height:100%;display:flex;align-items:center;justify-content:center;">
+      <div style="display:flex;flex-direction:column;align-items:center;gap:48px;font-family:'Inter', 'Helvetica Neue', Arial, sans-serif;font-weight:700;font-size:144px;color:#ffffff;">
+        <span style="display:inline-block;width:220px;height:220px;border-radius:50%;background:#F9C623;"></span>
+        <span>BeaSkyblue</span>
+      </div>
+    </div>
+  </foreignObject>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,20 @@
-const projects = [
+import Image from "next/image";
+
+type Project = {
+  title: string;
+  description: string;
+  href?: string;
+  thumbnail?: string;
+  thumbnailAlt?: string;
+};
+
+const projects: Project[] = [
   {
     title: "Blog",
     description: "Personal blog where I share updates and articles.",
     href: "https://www.beaskyblue.com/",
+    thumbnail: "/blog-thumbnail.svg",
+    thumbnailAlt: "BeaSkyblue blog project thumbnail",
   },
   { title: "Project 2", description: "Currently under development." },
   { title: "Project 3", description: "Currently under development." },
@@ -26,7 +38,19 @@ export default function HomePage() {
                 rel="noreferrer"
                 className="card p-5 transition hover:-translate-y-1 hover:shadow-lg"
               >
-                <div className="aspect-video w-full rounded-md bg-gradient-to-br from-brand-500/30 via-blue-500/20 to-purple-500/20" />
+                {project.thumbnail ? (
+                  <div className="relative aspect-video w-full overflow-hidden rounded-md">
+                    <Image
+                      src={project.thumbnail}
+                      alt={project.thumbnailAlt ?? `${project.title} thumbnail`}
+                      fill
+                      sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                      className="object-cover"
+                    />
+                  </div>
+                ) : (
+                  <div className="aspect-video w-full rounded-md bg-gradient-to-br from-brand-500/30 via-blue-500/20 to-purple-500/20" />
+                )}
                 <h3 className="mt-4 font-medium">{project.title}</h3>
                 <p className="mt-1 text-sm text-neutral-400">{project.description}</p>
               </a>


### PR DESCRIPTION
## Summary
- stack the BeaSkyblue blog thumbnail elements vertically to place the circle above the text
- keep the sky-blue background while updating the accessibility description for the new layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddfd37739c832eb00d4de9f6ab6765